### PR TITLE
Add ~ Support and Linux launch file 

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,6 @@ You need [Python3](https://www.python.org/downloads/) installed (and on the PATH
 
 You'll also need git installed and on the PATH, which you presumably should already if you have a git repository.
 
-Lastly, you'll need tkinter installed. You can install this with your package manager on Linux, or the installation exe on Windows. 
-
 
 # Usage
 

--- a/README.md
+++ b/README.md
@@ -17,11 +17,13 @@ You need [Python3](https://www.python.org/downloads/) installed (and on the PATH
 
 You'll also need git installed and on the PATH, which you presumably should already if you have a git repository.
 
+
+
 # Usage
 
 Download and extract the repository (click the green "Code" button -> "Download as zip").
 
-Launch the widget using `python git_linestats_widget.py` or by double clicking `launch.bat` on Windows. It will ask you for a path to a repository on the first run.
+Launch the widget using `python git_linestats_widget.py`, by double clicking `launch.bat` on Windows, or by running the 'launch.sh' file on Linux. It will ask you for a path to a repository on the first run.
 
 ![Repository prompt](https://i.imgur.com/hlNmFhn.png)
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Lastly, you'll need tkinter installed. You can install this with your package ma
 
 Download and extract the repository (click the green "Code" button -> "Download as zip").
 
-Launch the widget using `python git_linestats_widget.py`, by double clicking `launch.bat` on Windows, or by running the 'launch.sh' file on Linux. It will ask you for a path to a repository on the first run.
+Launch the widget using `python git_linestats_widget.py`, by double clicking `launch.bat` on Windows, or by running the `launch.sh` file on Linux. It will ask you for a path to a repository on the first run.
 
 ![Repository prompt](https://i.imgur.com/hlNmFhn.png)
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ You need [Python3](https://www.python.org/downloads/) installed (and on the PATH
 
 You'll also need git installed and on the PATH, which you presumably should already if you have a git repository.
 
+Lastly, you'll need tkinter installed. You can install this with your package manager on Linux, or the installation exe on Windows. 
 
 
 # Usage

--- a/git_linestats_widget.py
+++ b/git_linestats_widget.py
@@ -273,6 +273,9 @@ if __name__ == "__main__":
 
                 # Replace Windows-style path separators
                 temp_settings["repo"][0] = temp_settings["repo"][0].replace("\\", "/")
+
+                # expand ~ in 
+                temp_settings["repo"][0] = os.path.expanduser(temp_settings["repo"][0])
                 
 
 

--- a/git_linestats_widget.py
+++ b/git_linestats_widget.py
@@ -267,7 +267,12 @@ if __name__ == "__main__":
 
                 # Replace Windows-style path separators
                 temp_settings["repo"][0] = temp_settings["repo"][0].replace("\\", "/")
-            
+                
+
+            # expand ~ in all repo's specified
+            for index in range(0, len(temp_settings["repo"])):
+                temp_settings["repo"][index] = os.path.expanduser(temp_settings["repo"][index])
+
             # Verify all repositories
             for repo in temp_settings["repo"]:
                 if not os.path.exists(repo):

--- a/git_linestats_widget.py
+++ b/git_linestats_widget.py
@@ -274,7 +274,7 @@ if __name__ == "__main__":
                 # Replace Windows-style path separators
                 temp_settings["repo"][0] = temp_settings["repo"][0].replace("\\", "/")
 
-                # expand ~ in 
+                # expand ~ in input from user 
                 temp_settings["repo"][0] = os.path.expanduser(temp_settings["repo"][0])
                 
 

--- a/git_linestats_widget.py
+++ b/git_linestats_widget.py
@@ -244,11 +244,17 @@ if __name__ == "__main__":
                 with open("settings.json", "r") as settings_json:
                     temp_settings = json.load(settings_json)
             
+
             # Test settings. This section is mostly to maintain backwards compatibility with old settings files.
             
             # Check if we have the old style repo property
             if ("repo" in temp_settings and not isinstance(temp_settings["repo"], list)):
                 temp_settings["repo"] = [temp_settings["repo"]]
+
+
+            # expand ~ in all repo's specified
+            for index in range(0, len(temp_settings["repo"])):
+                temp_settings["repo"][index] = os.path.expanduser(temp_settings["repo"][index])
 
             # Check for a valid repository and ask for one if we don't have it
             if ("repo" not in temp_settings or
@@ -269,9 +275,6 @@ if __name__ == "__main__":
                 temp_settings["repo"][0] = temp_settings["repo"][0].replace("\\", "/")
                 
 
-            # expand ~ in all repo's specified
-            for index in range(0, len(temp_settings["repo"])):
-                temp_settings["repo"][index] = os.path.expanduser(temp_settings["repo"][index])
 
             # Verify all repositories
             for repo in temp_settings["repo"]:

--- a/launch.sh
+++ b/launch.sh
@@ -1,0 +1,4 @@
+#~/bin/bash
+
+python3 git_linestats_widget.py
+


### PR DESCRIPTION
File paths without `~` work as intended but fail with that specifier. I fixed this by expanding it into an absolute path when both read in from the settings.json file and specified through the popup. In addition to that I made launch.sh which functions the same as launch.bat. The README was also updated to reflect these changes. 